### PR TITLE
Fix: Correct import path in models.py

### DIFF
--- a/server/domain/models.py
+++ b/server/domain/models.py
@@ -12,9 +12,9 @@ from sqlalchemy import (
     ForeignKey, Text, UniqueConstraint, func
 )
 
-from database import Base
-from schemas import (
-    UserRole, SiteStatus, CraneStatus, 
+from server.database import Base
+from server.domain.schemas import (
+    UserRole, SiteStatus, CraneStatus,
     AssignmentStatus, DocItemStatus, OrgType
 )
 


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError` that occurred when running the server. The `server/domain/models.py` file was trying to import `Base` from the `database` module, but the correct path is `server.database`.

This change updates the import statement to use the correct path.