### PR TITLE
Fix: Import Crane model in repositories.py

### DIFF
--- a/server/domain/repositories.py
+++ b/server/domain/repositories.py
@@ -5,7 +5,7 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from server.domain.models import Base
+from server.domain.models import Base, Crane
 
 # Define custom types for SQLAlchemy models and Pydantic schemas
 ModelType = TypeVar("ModelType", bound=Base)


### PR DESCRIPTION
This commit fixes a `NameError` that occurred when running the server. The `server/domain/repositories.py` file was using the `Crane` model without importing it.

This change adds the `Crane` model to the import statement at the top of the file.