### PR TITLE
Fix: Add hashed_password column to users table

### DIFF
--- a/sql/init_db.sql
+++ b/sql/init_db.sql
@@ -78,6 +78,7 @@ CREATE TABLE ops.users (
   id          TEXT PRIMARY KEY DEFAULT uuid_generate_v4()::text,
   email       CITEXT UNIQUE NOT NULL,
   name        TEXT NOT NULL,
+  hashed_password TEXT NOT NULL,
   role        ops.user_role NOT NULL,
   is_active   BOOLEAN NOT NULL DEFAULT true,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),


### PR DESCRIPTION
This commit fixes an `UndefinedColumn` error that occurred when running the server. The `User` model had a `hashed_password` attribute, but the `users` table in the database did not have the corresponding column.

This change adds the `hashed_password` column to the `users` table in the `sql/init_db.sql` file.