### PR TITLE
fix: Add missing dependencies to package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,14 +9,20 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.6.0",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.2.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "axios": "^1.6.0"
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   }


### PR DESCRIPTION
This commit adds the missing frontend dependencies (`tailwindcss`, `postcss`, `autoprefixer`, `framer-motion`, `clsx`, `tailwind-merge`) to the `client/package.json` file.

These dependencies were installed during development but were not correctly saved to `package.json` due to environment issues, causing the application to fail on other machines. This fix ensures that a clean `npm install` will set up the project correctly.