### PR TITLE
fix: Convert postcss and tailwind configs to .cjs

### DIFF
--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
This commit converts the `postcss.config.js` and `tailwind.config.js` files to use the `.cjs` extension and `module.exports` syntax.

This change is intended to fix a module loading issue where PostCSS could not find the `tailwindcss` module, even when it was correctly installed. Using the CommonJS format for these configuration files is a common workaround for such tooling and environment compatibility problems.