### PR TITLE
fix: Add missing Optional import in services.py

### DIFF
--- a/server/domain/services.py
+++ b/server/domain/services.py
@@ -1,6 +1,6 @@
 import logging
 import datetime as dt
-from typing import List
+from typing import List, Optional
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because `Optional` was used as a type hint in the `list_sites` method signature without being imported from the `typing` module.