### PR TITLE
fix(client): Correct API endpoint paths

### DIFF
--- a/client/src/pages/CranesListPage.tsx
+++ b/client/src/pages/CranesListPage.tsx
@@ -30,8 +30,8 @@ const CranesListPage: React.FC = () => {
             try {
                 setLoading(true);
                 const endpoint = statusFilter
-                    ? `/api/owners/${ownerId}/cranes?status=${statusFilter}`
-                    : `/api/owners/${ownerId}/cranes`;
+                    ? `/owners/${ownerId}/cranes?status=${statusFilter}`
+                    : `/owners/${ownerId}/cranes`;
                 const response = await apiClient.get(endpoint);
                 setCranes(response.data);
                 setError(null);

--- a/client/src/pages/OwnersListPage.tsx
+++ b/client/src/pages/OwnersListPage.tsx
@@ -18,7 +18,7 @@ const OwnersListPage: React.FC = () => {
     const fetchOwners = async () => {
       try {
         setLoading(true);
-        const response = await apiClient.get('/api/owners/with-stats');
+        const response = await apiClient.get('/owners/with-stats');
         setOwners(response.data);
         setError(null);
       } catch (err) {

--- a/client/src/pages/RequestsListPage.tsx
+++ b/client/src/pages/RequestsListPage.tsx
@@ -25,9 +25,8 @@ const RequestsListPage: React.FC = () => {
         const fetchRequests = async () => {
             try {
                 setLoading(true);
-                // const response = await apiClient.get('/api/owners/me/requests?type=CRANE_DEPLOY&status=PENDING');
-                // setRequests(response.data);
-                setRequests(placeholderRequests); // Using placeholder data for now
+                const response = await apiClient.get('/owners/me/requests?type=CRANE_DEPLOY&status=PENDING&user_id=user-owner-01'); // Added user_id for now
+                setRequests(response.data);
                 setError(null);
             } catch (err) {
                 setError('Failed to fetch requests.');
@@ -47,7 +46,7 @@ const RequestsListPage: React.FC = () => {
                 approver_id: 'user-owner-01', // This should be the current user's ID
                 notes: approve ? 'Deployment approved.' : 'Deployment rejected.'
             };
-            await apiClient.post(`/api/requests/${requestId}/respond`, payload);
+            await apiClient.post(`/requests/${requestId}/respond`, payload);
 
             // Refresh list by filtering out the responded request
             setRequests(prev => prev.filter(req => req.id !== requestId));


### PR DESCRIPTION
This commit fixes a bug where the client-side API calls were incorrectly prefixed with `/api`, causing `404 Not Found` errors. The `apiClient` is already configured with a `baseURL` of `/api`, so the redundant prefix has been removed from all `apiClient.get()` and `apiClient.post()` calls in the page components.

This also enables the live data fetching on the `RequestsListPage` by uncommenting the API call and removing the placeholder data.