### PR TITLE
fix(api): Correct routing for list_owner_cranes endpoint

### DIFF
--- a/server/api/routers/cranes.py
+++ b/server/api/routers/cranes.py
@@ -18,19 +18,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.get("/owners/{owner_org_id}/cranes", response_model=List[CraneOut])
-def list_owner_cranes(
-    owner_org_id: str,
-    status: Optional[CraneStatus] = None,
-    db: Session = Depends(get_db),
-):
-    """
-    List all cranes owned by a specific organization, with an optional filter for
-    status.
-    """
-    return crane_service.list_owner_cranes(
-        db=db, owner_org_id=owner_org_id, status=status
-    )
 
 
 @router.post(

--- a/server/api/routers/owners.py
+++ b/server/api/routers/owners.py
@@ -5,8 +5,15 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from server.database import get_db
-from server.domain.schemas import OwnerStatsOut, RequestOut, RequestStatus, RequestType
-from server.domain.services import owner_service
+from server.domain.schemas import (
+    CraneOut,
+    CraneStatus,
+    OwnerStatsOut,
+    RequestOut,
+    RequestStatus,
+    RequestType,
+)
+from server.domain.services import owner_service, crane_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -25,6 +32,19 @@ def list_owners_with_stats(db: Session = Depends(get_db)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error",
         )
+
+
+@router.get("/{owner_id}/cranes", response_model=List[CraneOut])
+def list_owner_cranes(
+    owner_id: str,
+    status: Optional[CraneStatus] = None,
+    db: Session = Depends(get_db),
+):
+    """
+    List all cranes owned by a specific organization, with an optional filter for
+    status.
+    """
+    return crane_service.list_owner_cranes(db=db, owner_org_id=owner_id, status=status)
 
 
 @router.get("/me/requests", response_model=List[RequestOut])


### PR DESCRIPTION
This commit fixes a 404 error that occurred when trying to fetch an owner's cranes. The `GET /owners/{owner_id}/cranes` endpoint was incorrectly placed in the `cranes.py` router instead of the `owners.py` router.

The `cranes.py` router is prefixed with `/cranes`, so the endpoint was being served at `/api/cranes/owners/...`, which did not match the client's request to `/api/owners/...`.

This change moves the `list_owner_cranes` endpoint from the `cranes` router to the `owners` router, aligning the API structure with the intended URL paths and resolving the 404 error.