### PR TITLE
fix(scripts): Update dev.ps1 to use procedural seeder

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -82,7 +82,8 @@ function Initialize-Database {
         psql -h $env:PGHOST -U $env:PGUSER -d $env:PGDATABASE -v ON_ERROR_STOP=1 -f "$ProjectRoot/sql/init_db.sql"
         psql -h $env:PGHOST -U $env:PGUSER -d $env:PGDATABASE -v ON_ERROR_STOP=1 -f "$ProjectRoot/sql/init_view.sql"
         psql -h $env:PGHOST -U $env:PGUSER -d $env:PGDATABASE -v ON_ERROR_STOP=1 -f "$ProjectRoot/sql/truncate.sql"
-        psql -h $env:PGHOST -U $env:PGUSER -d $env:PGDATABASE -v ON_ERROR_STOP=1 -f "$ProjectRoot/sql/seed.sql"
+        Write-SubStep "Running procedural seeder..."
+        python "$ProjectRoot/scripts/procedural_seed.py"
     } else {
         Write-SubStep "psql not found, falling back to Python runner."
         python "$ProjectRoot/scripts/db_runner.py" "full"


### PR DESCRIPTION
This commit fixes a bug in the `dev.ps1` PowerShell script where it was still attempting to execute the deleted `sql/seed.sql` file.

The script has been updated to call the new `scripts/procedural_seed.py` script directly, aligning its behavior with the `dev.sh` script and ensuring the database is seeded correctly in a Windows environment.