### PR TITLE
feat: Add crane model specifications and search

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import OwnersListPage from './pages/OwnersListPage';
 import TestClientPage from './pages/TestClientPage';
 import CranesListPage from './pages/CranesListPage';
 import RequestsListPage from './pages/RequestsListPage';
+import CraneModelSearchPage from './pages/CraneModelSearchPage';
 import './components/Particles.css';
 
 const App: React.FC = () => {
@@ -35,6 +36,9 @@ const App: React.FC = () => {
               <NavLink to="/sites" className={navLinkClasses}>
                 Sites
               </NavLink>
+              <NavLink to="/crane-models" className={navLinkClasses}>
+                Crane Models
+              </NavLink>
               <NavLink to="/requests" className={navLinkClasses}>
                 Requests
               </NavLink>
@@ -52,6 +56,7 @@ const App: React.FC = () => {
           <Route path="/owners" element={<OwnersListPage />} />
           <Route path="/owners/:ownerId/cranes" element={<CranesListPage />} />
           <Route path="/requests" element={<RequestsListPage />} />
+          <Route path="/crane-models" element={<CraneModelSearchPage />} />
           <Route path="/test-client" element={<TestClientPage />} />
           {/* Add other routes here as pages are created */}
         </Routes>

--- a/client/src/pages/CraneModelSearchPage.tsx
+++ b/client/src/pages/CraneModelSearchPage.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import apiClient from '../apiClient';
+
+interface CraneModel {
+    id: string;
+    model_name: string;
+    max_lifting_capacity_ton_m?: number;
+    max_working_height_m?: number;
+    max_working_radius_m?: number;
+}
+
+const CraneModelSearchPage: React.FC = () => {
+    const [models, setModels] = useState<CraneModel[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    // Add state for search filters here
+
+    useEffect(() => {
+        const fetchModels = async () => {
+            try {
+                setLoading(true);
+                // Add filter query params to the endpoint as needed
+                const response = await apiClient.get('/crane-models');
+                setModels(response.data);
+                setError(null);
+            } catch (err) {
+                setError('Failed to fetch crane models.');
+                console.error(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchModels();
+    }, []); // Add filters to dependency array when implemented
+
+    if (loading) return <div className="text-center text-cyan-glow">Loading Models...</div>;
+    if (error) return <div className="text-center text-red-500">{error}</div>;
+
+    return (
+        <div>
+            <h1 className="text-3xl font-bold text-cyan-glow mb-6">Search Crane Models</h1>
+            {/* Add filter inputs here */}
+            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {models.map((model) => (
+                    <div key={model.id} className="bg-gray-800 p-6 rounded-lg border border-gray-700">
+                        <h2 className="text-xl font-bold text-white">{model.model_name}</h2>
+                        <div className="mt-2 text-sm text-gray-400 space-y-1">
+                            <p>Max Lift: {model.max_lifting_capacity_ton_m || 'N/A'} ton·m</p>
+                            <p>Max Height: {model.max_working_height_m || 'N/A'} m</p>
+                            <p>Max Radius: {model.max_working_radius_m || 'N/A'} m</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default CraneModelSearchPage;

--- a/client/src/pages/CranesListPage.tsx
+++ b/client/src/pages/CranesListPage.tsx
@@ -10,11 +10,19 @@ enum CraneStatus {
     INBOUND = "INBOUND",
 }
 
-interface Crane {
+interface CraneModel {
     id: string;
     model_name: string;
+    max_lifting_capacity_ton_m?: number;
+    max_working_height_m?: number;
+    max_working_radius_m?: number;
+}
+
+interface Crane {
+    id: string;
     serial_no: string;
     status: CraneStatus;
+    model: CraneModel;
 }
 
 const CranesListPage: React.FC = () => {
@@ -78,8 +86,12 @@ const CranesListPage: React.FC = () => {
                 {cranes.map((crane) => (
                     <div key={crane.id} className="bg-gray-800 p-6 rounded-lg border border-gray-700 flex flex-col justify-between">
                         <div>
-                            <h2 className="text-xl font-bold text-white">{crane.model_name}</h2>
-                            <p className="text-sm text-gray-400">{crane.serial_no}</p>
+                            <h2 className="text-xl font-bold text-white">{crane.model.model_name}</h2>
+                            <p className="text-sm text-gray-400">S/N: {crane.serial_no}</p>
+                            <div className="mt-2 text-xs text-gray-500 space-y-1">
+                                <p>Max Lift: {crane.model.max_lifting_capacity_ton_m} ton·m</p>
+                                <p>Max Height: {crane.model.max_working_height_m} m</p>
+                            </div>
                         </div>
                         <div className="mt-4 flex justify-between items-center">
                             <span className={`px-3 py-1 rounded-full text-xs font-bold ${

--- a/scripts/procedural_seed.py
+++ b/scripts/procedural_seed.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import text
 
 # This is a standalone script, so we need to set up the path
 # to import from the server directory.
@@ -10,8 +11,10 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from server.database import db_manager
-from server.domain.models import Org, User, Crane, UserOrg
+from server.domain.models import Org, User, Crane, UserOrg, CraneModel
 from server.domain.schemas import OrgType, UserRole, CraneStatus
+import json
+import random
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -41,6 +44,62 @@ USERS = [
     {"id": "user-driver-03", "email": "driver3@dy.local", "name": "Driver C", "role": UserRole.DRIVER},
 ]
 
+CRANE_MODELS = [
+    {
+        "model_name": "SS1926", "max_lifting_capacity_ton_m": 18, "max_working_height_m": 22.7, "max_working_radius_m": 19.8,
+        "iver_torque_phi_mm": "10x100", "boom_sections": 6, "tele_speed_m_sec": "15.1/36", "boom_angle_speed_deg_sec": "80/17",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 5600, "distance": 30}, {"load": 3800, "distance": 47}, {"load": 2100, "distance": 77}, {"load": 1700, "distance": 87}, {"load": 850, "distance": 137}, {"load": 500, "distance": 168}, {"load": 390, "distance": 207}]),
+        "optional_specs": ["SUB WINCH"]
+    },
+    {
+        "model_name": "SS1406", "max_lifting_capacity_ton_m": 14, "max_working_height_m": 18.3, "max_working_radius_m": 16.35,
+        "iver_torque_phi_mm": "10x90", "boom_sections": 5, "tele_speed_m_sec": "12.3/32", "boom_angle_speed_deg_sec": "78/12.5",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 5600, "distance": 28}, {"load": 3500, "distance": 40}, {"load": 2000, "distance": 62}, {"load": 1600, "distance": 69}, {"load": 850, "distance": 114}, {"load": 700, "distance": 132}, {"load": 450, "distance": 163}]),
+        "optional_specs": ["SUB WINCH"]
+    },
+    {
+        "model_name": "ST2217D", "max_lifting_capacity_ton_m": 22, "max_working_height_m": 25.7, "max_working_radius_m": 22.6,
+        "iver_torque_phi_mm": "10x100", "boom_sections": 7, "tele_speed_m_sec": "17.8/25", "boom_angle_speed_deg_sec": "-17~80/19",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 6000, "distance": 30}, {"load": 4500, "distance": 48}, {"load": 3200, "distance": 76}, {"load": 1800, "distance": 113}, {"load": 1000, "distance": 138}, {"load": 750, "distance": 167}, {"load": 500, "distance": 207}]),
+        "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "SS2037D", "max_lifting_capacity_ton_m": 22, "max_working_height_m": 25.7, "max_working_radius_m": 22.6,
+        "iver_torque_phi_mm": "10x100", "boom_sections": 7, "tele_speed_m_sec": "17.8/37", "boom_angle_speed_deg_sec": "-17~80/19",
+        "lifting_load_distance_kg_m": None, "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "ST2217", "max_lifting_capacity_ton_m": 22, "max_working_height_m": 22.7, "max_working_radius_m": 19.8,
+        "iver_torque_phi_mm": "10x100", "boom_sections": 6, "tele_speed_m_sec": "17.1/23", "boom_angle_speed_deg_sec": "-17~80/19",
+        "lifting_load_distance_kg_m": None, "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "SS2036Ace", "max_lifting_capacity_ton_m": 22, "max_working_height_m": 22.7, "max_working_radius_m": 19.8,
+        "iver_torque_phi_mm": "10x100", "boom_sections": 6, "tele_speed_m_sec": "15.1/36", "boom_angle_speed_deg_sec": "-17~80/19",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 8000, "distance": 30}, {"load": 4500, "distance": 47}, {"load": 3200, "distance": 77}, {"load": 1800, "distance": 113}, {"load": 1000, "distance": 137}, {"load": 800, "distance": 168}, {"load": 600, "distance": 188}]),
+        "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "ST2516", "max_lifting_capacity_ton_m": 24, "max_working_height_m": 29.5, "max_working_radius_m": 26,
+        "iver_torque_phi_mm": "12x120", "boom_sections": 6, "tele_speed_m_sec": "19.8/26", "boom_angle_speed_deg_sec": "-15~80/23",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 12000, "distance": 30}, {"load": 5700, "distance": 61}, {"load": 2400, "distance": 101}, {"load": 1400, "distance": 141}, {"load": 950, "distance": 181}, {"load": 700, "distance": 220}, {"load": 500, "distance": 260}]),
+        "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "ST2517", "max_lifting_capacity_ton_m": 25, "max_working_height_m": 26.5, "max_working_radius_m": 23.5,
+        "iver_torque_phi_mm": "12x120", "boom_sections": 7, "tele_speed_m_sec": "18.5/27", "boom_angle_speed_deg_sec": "-15~80/23",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 12000, "distance": 30}, {"load": 6400, "distance": 50}, {"load": 3300, "distance": 81}, {"load": 1900, "distance": 112}, {"load": 1300, "distance": 143}, {"load": 1000, "distance": 174}, {"load": 700, "distance": 204}, {"load": 500, "distance": 233}]),
+        "optional_specs": ["SUB WINCH", "SUB BOOM", "DY-CABIN"]
+    },
+    {
+        "model_name": "ST7516", "max_lifting_capacity_ton_m": 70, "max_working_height_m": 34.5, "max_working_radius_m": 30.6,
+        "iver_torque_phi_mm": "14x150", "boom_sections": 6, "tele_speed_m_sec": "23.2/40", "boom_angle_speed_deg_sec": "-10~80/30",
+        "lifting_load_distance_kg_m": json.dumps([{"load": 20000, "distance": 30}, {"load": 8398, "distance": 74}, {"load": 4750, "distance": 120}, {"load": 2792, "distance": 164}, {"load": 2000, "distance": 213}, {"load": 1480, "distance": 269}, {"load": 1000, "distance": 352}]),
+        "optional_specs": ["SUB WINCH", "SUB BOOM", "SUBMODULE O/R"]
+    },
+]
+
+
 def seed_data(db: Session):
     logger.info("--- Seeding Organizations ---")
     for org_data in ORGS:
@@ -62,28 +121,37 @@ def seed_data(db: Session):
                 db.add(UserOrg(user_id=user.id, org_id=org_id))
     db.commit()
 
-    logger.info("--- Seeding Cranes ---")
+    logger.info("--- Seeding Crane Models ---")
+    model_ids = []
+    for model_data in CRANE_MODELS:
+        model = db.query(CraneModel).filter(CraneModel.model_name == model_data["model_name"]).first()
+        if not model:
+            model = CraneModel(**model_data)
+            db.add(model)
+    db.commit()
+    # Get all model IDs to randomly assign them later
+    model_ids = [m.id for m in db.query(CraneModel.id).all()]
+
+
+    logger.info("--- Seeding Crane Instances ---")
+    # First, truncate the existing cranes to reset them
+    db.execute(text("TRUNCATE TABLE ops.cranes RESTART IDENTITY CASCADE"))
+
     for i in range(1, 6):
         owner_id = f"org-owner-0{i}"
         for j in range(1, 11):
-            if j <= 5:
-                model, prefix = "TRUCK-80T", "TRK80"
-            else:
-                model, prefix = "CRAWLER-150T", "CRW150"
-
             status = CraneStatus.NORMAL
             if j % 10 == 0: status = CraneStatus.REPAIR
             elif j % 10 == 9: status = CraneStatus.INBOUND
 
-            serial_no = f"SN-{prefix}-{str(i).zfill(2)}{str(j).zfill(3)}"
-            crane = db.query(Crane).filter(Crane.serial_no == serial_no).first()
-            if not crane:
-                db.add(Crane(
-                    owner_org_id=owner_id,
-                    model_name=model,
-                    serial_no=serial_no,
-                    status=status
-                ))
+            serial_no = f"SN-DY-{str(i).zfill(2)}{str(j).zfill(3)}"
+
+            db.add(Crane(
+                owner_org_id=owner_id,
+                model_id=random.choice(model_ids),
+                serial_no=serial_no,
+                status=status
+            ))
     db.commit()
     logger.info("--- Seeding complete ---")
 

--- a/server/api/routers/crane_models.py
+++ b/server/api/routers/crane_models.py
@@ -1,0 +1,19 @@
+import logging
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from server.database import get_db
+from server.domain.schemas import CraneModelOut
+from server.domain.services.crane_model_service import crane_model_service
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/", response_model=List[CraneModelOut])
+def list_crane_models(db: Session = Depends(get_db)):
+    """
+    List all crane models with optional filtering.
+    """
+    return crane_model_service.get_models(db=db)

--- a/server/api/routes.py
+++ b/server/api/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from server.api.routers import (
     assignments,
+    crane_models,
     cranes,
     documents,
     health,
@@ -15,6 +16,9 @@ api_router = APIRouter(prefix="/api")
 api_router.include_router(health.router, prefix="/health", tags=["health"])
 api_router.include_router(sites.router, prefix="/sites", tags=["sites"])
 api_router.include_router(cranes.router, prefix="/cranes", tags=["cranes"])
+api_router.include_router(
+    crane_models.router, prefix="/crane-models", tags=["crane-models"]
+)
 api_router.include_router(owners.router, prefix="/owners", tags=["owners"])
 api_router.include_router(
     assignments.router, prefix="/assignments", tags=["assignments"]

--- a/server/domain/repositories.py
+++ b/server/domain/repositories.py
@@ -12,6 +12,7 @@ from server.domain.models import (
     DriverAttendance,
     Base,
     Crane,
+    CraneModel,
     DriverAssignment,
     DriverDocumentItem,
     DriverDocumentRequest,
@@ -37,6 +38,8 @@ from server.domain.schemas import (
     SiteUpdate,
     UserCreate,
     UserUpdate,
+    CraneModelCreate,
+    CraneModelUpdate,
 )
 
 # Define custom types for SQLAlchemy models and Pydantic schemas
@@ -211,11 +214,13 @@ class UserRepository(BaseRepository[User, UserCreate, UserUpdate]):
         return cast(Optional[User], db.query(User).filter(User.email == email).first())
 
 
+from sqlalchemy.orm import joinedload
+
 class CraneRepository(BaseRepository[Crane, CraneCreate, CraneUpdate]):
     def get_by_owner(
         self, db: Session, *, owner_org_id: str, status: Optional[CraneStatus] = None
     ) -> List[Crane]:
-        query = db.query(Crane).filter(Crane.owner_org_id == owner_org_id)
+        query = db.query(Crane).options(joinedload(Crane.model)).filter(Crane.owner_org_id == owner_org_id)
         if status:
             query = query.filter(Crane.status == status)
         return cast(List[Crane], query.all())
@@ -255,9 +260,14 @@ class AttendanceRepository(
     pass
 
 
+class CraneModelRepository(BaseRepository[CraneModel, CraneModelCreate, CraneModelUpdate]):
+    pass
+
+
 site_repo = SiteRepository(Site)
 user_repo = UserRepository(User)
 crane_repo = CraneRepository(Crane)
+crane_model_repo = CraneModelRepository(CraneModel)
 site_crane_assignment_repo = SiteCraneAssignmentRepository(SiteCraneAssignment)
 driver_assignment_repo = DriverAssignmentRepository(DriverAssignment)
 document_request_repo = DocumentRequestRepository(DriverDocumentRequest)

--- a/server/domain/schemas.py
+++ b/server/domain/schemas.py
@@ -233,6 +233,18 @@ class SiteOut(BaseModel):
     updated_at: dt.datetime
 
 
+class CraneModelOut(BaseModel):
+    """Schema for crane model specifications in API responses."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    model_name: str
+    max_lifting_capacity_ton_m: Optional[int] = None
+    max_working_height_m: Optional[float] = None
+    max_working_radius_m: Optional[float] = None
+    optional_specs: Optional[List[str]] = None
+
+
 class CraneOut(BaseModel):
     """Schema for crane information in API responses."""
 
@@ -240,9 +252,9 @@ class CraneOut(BaseModel):
 
     id: str
     owner_org_id: str
-    model_name: str
     serial_no: Optional[str] = None
     status: CraneStatus
+    model: CraneModelOut
     created_at: dt.datetime
     updated_at: dt.datetime
 
@@ -311,18 +323,38 @@ class UserUpdate(UserBase):
     password: Optional[str] = None
 
 
+from typing import List, Any
+
 # ========= CRANE SCHEMAS =========
+
+class CraneModelBase(BaseModel):
+    model_name: str
+    max_lifting_capacity_ton_m: Optional[int] = None
+    max_working_height_m: Optional[float] = None
+    max_working_radius_m: Optional[float] = None
+    iver_torque_phi_mm: Optional[str] = None
+    boom_sections: Optional[int] = None
+    tele_speed_m_sec: Optional[str] = None
+    boom_angle_speed_deg_sec: Optional[str] = None
+    lifting_load_distance_kg_m: Optional[Any] = None
+    optional_specs: Optional[List[str]] = None
+
+class CraneModelCreate(CraneModelBase):
+    pass
+
+class CraneModelUpdate(CraneModelBase):
+    pass
 
 
 class CraneBase(BaseModel):
-    model_name: Optional[str] = None
+    model_id: Optional[str] = None
     serial_no: Optional[str] = None
     status: Optional[CraneStatus] = CraneStatus.NORMAL
     owner_org_id: Optional[str] = None
 
 
 class CraneCreate(CraneBase):
-    model_name: str
+    model_id: str
     owner_org_id: str
 
 

--- a/server/domain/services/crane_model_service.py
+++ b/server/domain/services/crane_model_service.py
@@ -1,0 +1,24 @@
+import logging
+from typing import List, Optional
+from sqlalchemy.orm import Session
+from server.domain.models import CraneModel
+from server.domain.repositories import crane_model_repo
+
+logger = logging.getLogger(__name__)
+
+class CraneModelService:
+    def get_models(self, db: Session, *, skip: int = 0, limit: int = 100) -> List[CraneModel]:
+        """
+        Retrieves a list of crane models.
+        """
+        logger.info("Fetching list of crane models")
+        return crane_model_repo.get_multi(db, skip=skip, limit=limit)
+
+    def get_model(self, db: Session, model_id: str) -> Optional[CraneModel]:
+        """
+        Retrieves a single crane model by its ID.
+        """
+        logger.info(f"Fetching crane model with id: {model_id}")
+        return crane_model_repo.get(db, id=model_id)
+
+crane_model_service = CraneModelService()

--- a/sql/init_db.sql
+++ b/sql/init_db.sql
@@ -130,10 +130,28 @@ CREATE TABLE ops.sites (
 );
 
 -- Cranes owned by organizations
+-- Crane models with detailed specifications
+CREATE TABLE ops.crane_models (
+    id TEXT PRIMARY KEY DEFAULT uuid_generate_v4()::text,
+    model_name TEXT NOT NULL UNIQUE,
+    max_lifting_capacity_ton_m INTEGER,
+    max_working_height_m NUMERIC(5, 2),
+    max_working_radius_m NUMERIC(5, 2),
+    iver_torque_phi_mm TEXT,
+    boom_sections INTEGER,
+    tele_speed_m_sec TEXT,
+    boom_angle_speed_deg_sec TEXT,
+    lifting_load_distance_kg_m JSONB,
+    optional_specs TEXT[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Cranes owned by organizations (instances of models)
 CREATE TABLE ops.cranes (
   id            TEXT PRIMARY KEY DEFAULT uuid_generate_v4()::text,
   owner_org_id  TEXT NOT NULL REFERENCES ops.orgs(id) ON DELETE RESTRICT,
-  model_name    TEXT NOT NULL,
+  model_id      TEXT NOT NULL REFERENCES ops.crane_models(id) ON DELETE RESTRICT,
   serial_no     TEXT UNIQUE,
   status        ops.crane_status NOT NULL DEFAULT 'NORMAL',
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),


### PR DESCRIPTION
This commit introduces a major architectural change to separate the concept of a crane 'model' (with detailed specifications) from a crane 'instance' (a specific, owned crane).

Key changes:

1.  **Database Schema:**
    - A new `crane_models` table has been added to store the detailed specifications for 9 different DY Crane models.
    - The existing `cranes` table has been modified to reference a `model_id` via foreign key, replacing the old free-text `model_name`.

2.  **Procedural Seeding:**
    - The `procedural_seed.py` script has been updated to first populate the `crane_models` table.
    - It then creates 50 crane instances (10 for each of the 5 owners) that are randomly assigned one of the new, detailed models.

3.  **API Layer:**
    - A new `/api/crane-models` endpoint has been created to allow listing and searching for crane models based on their specs.
    - The existing `/api/owners/{ownerId}/cranes` endpoint has been updated to join with the `crane_models` table, so that the full model details are included in the response for each crane instance.
    - The corresponding schemas, services, and repositories have been created or updated to support this new structure.

4.  **Frontend UI:**
    - The "Cranes List" page has been updated to display the detailed model name and key specs for each crane.
    - A new "Crane Models" page has been added to the navigation, providing a placeholder for a future UI to search and filter models.