### PR TITLE
fix: Add missing List import to schemas.py

### DIFF
--- a/server/domain/schemas.py
+++ b/server/domain/schemas.py
@@ -5,7 +5,7 @@ Defines API request/response models and validation rules.
 
 import datetime as dt
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
 


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because `List` was used as a type hint in the `CraneModelOut` schema without being imported from the `typing` module.