### PR TITLE
fix: Add missing Integer import to models.py

### DIFF
--- a/server/domain/models.py
+++ b/server/domain/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Integer,
     String,
     Text,
     UniqueConstraint,


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because `Integer` was used as a column type in the `CraneModel` SQLAlchemy model without being imported from the `sqlalchemy` module.