### PR TITLE
fix: Correct baseURL for test client API requests

### DIFF
--- a/client/src/pages/test-client/transport/apiAdapter.ts
+++ b/client/src/pages/test-client/transport/apiAdapter.ts
@@ -30,8 +30,7 @@ async function request<T>(
 
   const requestConfig: AxiosRequestConfig = {
     ...config,
-    headers,
-    baseURL: `${context.host || 'http://localhost:8000'}`
+    headers
   };
 
   actions.addLog({


### PR DESCRIPTION
The test client's apiAdapter was overriding the apiClient's baseURL, causing requests to be sent to the wrong URL (e.g., /sites/ instead of /api/sites/). This resulted in 404 Not Found errors.

This commit removes the baseURL override in the apiAdapter, allowing it to use the correct baseURL from the apiClient. This ensures that test client requests are proxied correctly to the backend API.