### PR TITLE
fix: Correct URL for listing owner cranes

### DIFF
--- a/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
+++ b/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
@@ -14,7 +14,7 @@ export async function listOwnerCranes(input: StepInput): Promise<ListCranesOutpu
       throw new Error('Owner or owner organization ID not found in context');
     }
 
-    const response = await apiAdapter.get('OWNER', `/cranes/owners/${owner.orgId}/cranes`);
+    const response = await apiAdapter.get('OWNER', `/owners/${owner.orgId}/cranes`);
     const craneId = response.data[0]?.id;
 
     if (!craneId) {


### PR DESCRIPTION
The test client was using an incorrect URL to list an owner's cranes, causing a 404 Not Found error. The URL segments were in the wrong order.

This commit corrects the URL in `C1_listOwnerCranes.ts` from `/cranes/owners/...` to `/owners/.../cranes`, which matches the API route definition.