### PR TITLE
fix(client): Correct baseURL for test client API requests

### DIFF
--- a/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
+++ b/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
@@ -14,7 +14,7 @@ export async function listOwnerCranes(input: StepInput): Promise<ListCranesOutpu
       throw new Error('Owner or owner organization ID not found in context');
     }
 
-    const response = await apiAdapter.get('OWNER', `/owners/${owner.orgId}/cranes`);
+    const response = await apiAdapter.get('OWNER', `/cranes/owners/${owner.orgId}/cranes`);
     const craneId = response.data[0]?.id;
 
     if (!craneId) {


### PR DESCRIPTION
The test client's apiAdapter was overriding the apiClient's baseURL, causing requests to be sent to the wrong URL (e.g., /sites/ instead of /api/sites/). This resulted in 404 Not Found errors.

This commit removes the baseURL override in the apiAdapter, allowing it to use the correct baseURL from the apiClient. This ensures that test client requests are proxied correctly to the backend API.