### PR TITLE
feat(api,client): Gracefully handle assignment conflicts

### DIFF
--- a/server/domain/services.py
+++ b/server/domain/services.py
@@ -221,7 +221,10 @@ class AssignmentService:
         if overlapping_assignment:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=f"Crane {assignment_in.crane_id} is already assigned during the requested period.",
+                detail={
+                    "message": f"Crane {assignment_in.crane_id} is already assigned during the requested period.",
+                    "assignment_id": overlapping_assignment.id,
+                },
             )
 
         assignment_data = SiteCraneAssignmentCreate(


### PR DESCRIPTION
When attempting to create a crane assignment that overlaps with an existing one, the API now returns a 409 Conflict status. The response body includes the ID of the existing, conflicting assignment.

The test client has been updated to handle this 409 error. When it receives a 409, it extracts the existing assignment ID from the response and uses it to proceed with the test workflow. This allows the test to continue as if the assignment was successful, per the specified requirements.