### PR TITLE
Fix: Resolve circular dependency and complete test client UI

### DIFF
--- a/client/src/pages/test-client/transport/apiAdapter.ts
+++ b/client/src/pages/test-client/transport/apiAdapter.ts
@@ -7,14 +7,12 @@ const RETRY_DELAY = 1000; // 1s
 
 type Actor = keyof NonNullable<WorkflowContext['users']> | 'SYSTEM';
 
-// A wrapper to get the current state from the Zustand store outside of a React component
-const { getState } = useWorkflowStore;
-
 async function request<T>(
   actor: Actor,
   config: AxiosRequestConfig
 ): Promise<AxiosResponse<T>> {
-  const { context, actions } = getState();
+  // Call getState() inside the function to avoid circular dependency issues
+  const { context, actions } = useWorkflowStore.getState();
 
   let headers = { ...config.headers };
 


### PR DESCRIPTION
This commit fixes a critical `ReferenceError` caused by a circular dependency between the `workflowStore` and the `apiAdapter`. The call to `useWorkflowStore.getState()` is now deferred to runtime within the `request` function, resolving the module initialization deadlock.

This also includes the previous implementation of the new developer guide UI, which features a three-panel layout for workflow visualization and control. It addresses an earlier bug related to unhandled promise rejections during initialization.

With these fixes, the `/test-client` page should now render and function as intended.