### PR TITLE
Fix: Implement missing approval step to resolve 422 error

### DIFF
--- a/client/src/pages/test-client/state/workflowStore.ts
+++ b/client/src/pages/test-client/state/workflowStore.ts
@@ -4,6 +4,7 @@ import { createSite } from '../steps/B1_createSite';
 import { approveSite } from '../steps/B2_approveSite';
 import { listOwnerCranes } from '../steps/C1_listOwnerCranes';
 import { requestCraneAssignment } from '../steps/C3_requestCraneAssignment';
+import { approveRequest } from '../steps/C5_approveRequest';
 import { assignDriver } from '../steps/D1_assignDriver';
 import { recordAttendance } from '../steps/D2_recordAttendance';
 import { requestDocument } from '../steps/E1_requestDocument';
@@ -52,6 +53,7 @@ const stepFunctions: { [key: string]: (input: any) => Promise<any> } = {
   B2: approveSite,
   C1: listOwnerCranes,
   C3: requestCraneAssignment,
+  C5: approveRequest,
   D1: assignDriver,
   D2: recordAttendance,
   E1: requestDocument,
@@ -94,7 +96,6 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       try {
         const stepFn = stepFunctions[stepCode];
         if (stepFn) {
-          // Pass the whole context as top-level props to the step function
           const stepInput = { ...context, context, actions };
           const result = await stepFn(stepInput);
           if (result) {

--- a/client/src/pages/test-client/steps/C5_approveRequest.ts
+++ b/client/src/pages/test-client/steps/C5_approveRequest.ts
@@ -1,0 +1,27 @@
+import { apiAdapter } from '../transport/apiAdapter';
+import { StepInput } from './types';
+
+type ApproveRequestInput = StepInput & {
+  assignmentId: string; // This is the request_id from the previous step
+};
+
+export async function approveRequest(input: ApproveRequestInput): Promise<void> {
+  const { context, assignmentId } = input;
+  const owner = context.users?.OWNER;
+
+  if (!owner) {
+    throw new Error('Owner not found in context');
+  }
+
+  if (!assignmentId) {
+      throw new Error('assignmentId (request_id) not found in context for C5');
+  }
+
+  const approveData = {
+    status: 'APPROVED',
+    approver_id: owner.id,
+    notes: 'Approved via test client',
+  };
+
+  await apiAdapter.post('OWNER', `/requests/${assignmentId}/respond`, approveData);
+}


### PR DESCRIPTION
This commit resolves a `422 Unprocessable Content` error that occurred during the driver assignment step (D1).

The root cause was a missing step in the client-side workflow logic. The crane assignment request (C3) was not being approved (C5) before the application attempted to assign a driver to it.

This fix introduces the `C5_approveRequest` step and integrates it into the `workflowStore`, ensuring the correct sequence of operations.

This commit finalizes the implementation of the new developer guide test client, which should now be fully functional.