### PR TITLE
Debug: Add logging to E2 document submission step

### DIFF
--- a/client/src/pages/test-client/steps/E2_submitDocument.ts
+++ b/client/src/pages/test-client/steps/E2_submitDocument.ts
@@ -12,7 +12,17 @@ type SubmitDocumentOutput = {
 export async function submitDocument(
   input: SubmitDocumentInput
 ): Promise<SubmitDocumentOutput> {
-  const { docRequestId } = input;
+  const { actions, docRequestId } = input;
+
+  actions.addLog({
+    actor: 'DEBUG',
+    stepCode: 'E2',
+    summary: `Submitting document for request ID: ${docRequestId}`,
+  });
+
+  if (!docRequestId) {
+    throw new Error('docRequestId is missing for submitDocument step');
+  }
 
   const docSubmitData = {
     request_id: docRequestId,


### PR DESCRIPTION
A `400 Bad Request` is occurring during step E2. The cause is unclear. This commit adds a debug log to the `E2_submitDocument` function to print the `docRequestId` to the console.

This will help diagnose whether the ID is being passed correctly from the client's state. Submitting for the user to test and provide the logged value.