### PR TITLE
Debug: Log entire context after each step

### DIFF
--- a/client/src/pages/test-client/state/workflowStore.ts
+++ b/client/src/pages/test-client/state/workflowStore.ts
@@ -119,6 +119,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
           if (result) {
             const newContext = { ...get().context, ...result };
             set({ context: newContext });
+            console.log(`Context after step ${stepCode}:`, newContext); // DEBUG LOG
           }
         }
 


### PR DESCRIPTION
To diagnose a persistent 400 error in step E2, this commit adds a console log to the `runStep` action in the `workflowStore`.

This will print the full context object after each step, providing visibility into the application's state and helping to trace how `docRequestId` is being managed.

Submitting for user to test and provide console logs.