### PR TITLE
Fix: Correct import paths in TestClientPage

### DIFF
--- a/client/src/pages/TestClientPage.tsx
+++ b/client/src/pages/TestClientPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useWorkflowStore } from '../state/workflowStore';
-import { WORKFLOW_STEPS } from '../workflow-def';
+import { useWorkflowStore } from './test-client/state/workflowStore';
+import { WORKFLOW_STEPS } from './test-client/workflow-def';
 import { WorkflowStepCard } from './test-client/ui/WorkflowStepCard';
 
 const TestClientPage: React.FC = () => {


### PR DESCRIPTION
The component was using incorrect relative paths to import the `useWorkflowStore` and `WORKFLOW_STEPS` modules, causing a build failure.

This commit corrects the paths, which should allow the application to render correctly.