### PR TITLE
fix(frontend): Add missing patch method to apiAdapter

### DIFF
--- a/client/src/pages/test-client/transport/apiAdapter.ts
+++ b/client/src/pages/test-client/transport/apiAdapter.ts
@@ -74,6 +74,8 @@ export const apiAdapter = {
     request<T>(actor, { ...config, method: 'POST', url, data }),
   put: <T>(actor: Actor, url: string, data?: any, config?: AxiosRequestConfig) =>
     request<T>(actor, { ...config, method: 'PUT', url, data }),
+  patch: <T>(actor: Actor, url: string, data?: any, config?: AxiosRequestConfig) =>
+    request<T>(actor, { ...config, method: 'PATCH', url, data }),
   delete: <T>(actor: Actor, url: string, config?: AxiosRequestConfig) =>
     request<T>(actor, { ...config, method: 'DELETE', url }),
 };


### PR DESCRIPTION
This change fixes a runtime error in the E2E test client that occurred because the `apiAdapter` object was missing a `patch` method.

The "Approve Site" step (B2) was failing with the error "apiAdapter.patch is not a function". This change adds the `patch` method to the `apiAdapter` in `apiAdapter.ts`, following the same pattern as the existing `get`, `post`, `put`, and `delete` methods.