### PR TITLE
fix(frontend): Add missing item_id to review document payload

### DIFF
--- a/client/src/pages/test-client/steps/E3_reviewDocument.ts
+++ b/client/src/pages/test-client/steps/E3_reviewDocument.ts
@@ -14,6 +14,7 @@ export async function reviewDocument(input: ReviewDocumentInput): Promise<void> 
   }
 
   const docReviewData = {
+    item_id: docItemId,
     reviewer_id: safetyManager.id,
     approve: true,
   };


### PR DESCRIPTION
This change fixes a 422 Unprocessable Entity error that occurred during the "Review Document" step (E3) of the E2E test client workflow.

The backend endpoint `PATCH /api/document-items/{item_id}` expects the `item_id` to be present in the request body to validate the `DocItemReviewIn` schema. The frontend was not sending this field, causing a Pydantic validation error on the server.

This fix adds the `item_id` to the payload in `E3_reviewDocument.ts`, resolving the 422 error and allowing the workflow to complete.