### PR TITLE
fix(frontend): Fix multiple errors in test client workflow

### DIFF
--- a/client/src/pages/test-client/steps/E3_reviewDocument.ts
+++ b/client/src/pages/test-client/steps/E3_reviewDocument.ts
@@ -14,6 +14,7 @@ export async function reviewDocument(input: ReviewDocumentInput): Promise<void> 
   }
 
   const docReviewData = {
+    item_id: docItemId,
     reviewer_id: safetyManager.id,
     approve: true,
   };

--- a/client/src/pages/test-client/transport/apiAdapter.ts
+++ b/client/src/pages/test-client/transport/apiAdapter.ts
@@ -74,6 +74,8 @@ export const apiAdapter = {
     request<T>(actor, { ...config, method: 'POST', url, data }),
   put: <T>(actor: Actor, url: string, data?: any, config?: AxiosRequestConfig) =>
     request<T>(actor, { ...config, method: 'PUT', url, data }),
+  patch: <T>(actor: Actor, url: string, data?: any, config?: AxiosRequestConfig) =>
+    request<T>(actor, { ...config, method: 'PATCH', url, data }),
   delete: <T>(actor: Actor, url: string, config?: AxiosRequestConfig) =>
     request<T>(actor, { ...config, method: 'DELETE', url }),
 };


### PR DESCRIPTION
This change fixes a series of errors that were preventing the E2E test client's "Run All Steps" workflow from completing successfully.

The following fixes are included:
1.  **`SiteStatus` import error:** A `SyntaxError` was occurring because `SiteStatus` was being imported from the wrong file. This was fixed by creating a new `enums.ts` file for frontend enums and updating the import path.
2.  **Missing `patch` method:** The `apiAdapter` was missing a `patch` method, which caused the "Approve Site" step to fail. This method has been added.
3.  **422 Error in "Review Document":** The "Review Document" step was failing with a 422 error because the `item_id` was missing from the request payload. This has been added to the payload.