### PR TITLE
fix: Correct API paths in test client workflow

### DIFF
--- a/client/src/pages/test-client/workflow-def.ts
+++ b/client/src/pages/test-client/workflow-def.ts
@@ -83,7 +83,7 @@ export interface StepDefinition {
       actor: 'SM',
       description: '새 현장에 대한 “요청”을 제출한다. 직접 생성이 아닌 요청 기반 모델을 따른다.',
       dataFlow: { in: ['users.SAFETY_MANAGER'], out: ['siteId'] },
-      api: { method: 'POST', path: '/api/v1/org/sites', sample: sampleBodies.B1 },
+      api: { method: 'POST', path: '/org/sites', sample: sampleBodies.B1 },
     },
     {
       code: 'B2',
@@ -91,7 +91,7 @@ export interface StepDefinition {
       actor: 'MFR',
       description: '접수된 현장 요청을 승인한다. 요청/현장 상태 전이는 원자적으로 처리된다는 가정하에, 결과만 컨텍스트에 반영한다.',
       dataFlow: { in: ['siteId', 'users.MANUFACTURER'], out: ['site.status'] },
-      api: { method: 'PATCH', path: '/api/v1/org/sites/{siteId}', sample: sampleBodies.B2 },
+      api: { method: 'PATCH', path: '/org/sites/{siteId}', sample: sampleBodies.B2 },
     },
     {
       code: 'C1',
@@ -99,7 +99,7 @@ export interface StepDefinition {
       actor: 'SM',
       description: '특정 사업주의 가용 크레인 목록을 조회한다. 이후 배치 요청에 필요한 식별자들을 확보한다.',
       dataFlow: { in: ['users.OWNER'], out: ['craneId'] },
-      api: { method: 'GET', path: '/api/v1/org/owners/{owner.orgId}/cranes' },
+      api: { method: 'GET', path: '/org/owners/{owner.orgId}/cranes' },
     },
     {
       code: 'C3',
@@ -107,7 +107,7 @@ export interface StepDefinition {
       actor: 'SM',
       description: '가용 크레인 중 하나를 선택해 특정 현장으로의 배치를 요청한다(요청/승인 모델).',
       dataFlow: { in: ['siteId', 'craneId', 'users.SAFETY_MANAGER'], out: ['assignmentId'] },
-      api: { method: 'POST', path: '/api/v1/ops/crane-deployments', sample: sampleBodies.C3 },
+      api: { method: 'POST', path: '/ops/crane-deployments', sample: sampleBodies.C3 },
     },
     {
       code: 'D1',
@@ -115,7 +115,7 @@ export interface StepDefinition {
       actor: 'OWN',
       description: '배치된 크레인에 운전자를 배정한다.',
       dataFlow: { in: ['assignmentId', 'users.DRIVER'], out: ['driverAssignmentId'] },
-      api: { method: 'POST', path: '/api/v1/ops/driver-deployments', sample: sampleBodies.D1 },
+      api: { method: 'POST', path: '/ops/driver-deployments', sample: sampleBodies.D1 },
     },
     {
       code: 'D2',
@@ -123,7 +123,7 @@ export interface StepDefinition {
       actor: 'DRV',
       description: '해당 현장/크레인에 출근 상태를 기록한다. 후속 서류 절차의 전제가 된다.',
       dataFlow: { in: ['driverAssignmentId'], out: ['attendance.latest'] },
-      api: { method: 'POST', path: '/api/v1/ops/driver-attendance-logs', sample: sampleBodies.D2 },
+      api: { method: 'POST', path: '/ops/driver-attendance-logs', sample: sampleBodies.D2 },
     },
     {
       code: 'E1',
@@ -131,7 +131,7 @@ export interface StepDefinition {
       actor: 'SM',
       description: '특정 운전자에게 서류 제출을 요청한다.',
       dataFlow: { in: ['siteId', 'users.DRIVER', 'users.SAFETY_MANAGER'], out: ['docRequestId'] },
-      api: { method: 'POST', path: '/api/v1/compliance/document-requests', sample: sampleBodies.E1 },
+      api: { method: 'POST', path: '/compliance/document-requests', sample: sampleBodies.E1 },
     },
     {
       code: 'E2',
@@ -139,7 +139,7 @@ export interface StepDefinition {
       actor: 'DRV',
       description: '요청된 문서를 제출한다.',
       dataFlow: { in: ['docRequestId'], out: ['docItemId'] },
-      api: { method: 'POST', path: '/api/v1/compliance/document-items', sample: sampleBodies.E2 },
+      api: { method: 'POST', path: '/compliance/document-items', sample: sampleBodies.E2 },
     },
     {
       code: 'E3',
@@ -147,7 +147,7 @@ export interface StepDefinition {
       actor: 'SM',
       description: '제출된 문서를 검토/확정한다.',
       dataFlow: { in: ['docItemId', 'users.SAFETY_MANAGER'], out: ['doc.reviewed'] },
-      api: { method: 'POST', path: '/api/v1/compliance/document-items/{docItemId}/review', sample: sampleBodies.E3 },
+      api: { method: 'POST', path: '/compliance/document-items/{docItemId}/review', sample: sampleBodies.E3 },
     },
     {
       code: 'F1',


### PR DESCRIPTION
This commit fixes a bug where the test client was experiencing 404 errors after the API v1 refactoring.

The paths in `client/src/pages/test-client/workflow-def.ts` were incorrectly prefixed with `/api/v1`, which was redundant as the API client already has `/api/v1` as its base URL. This resulted in incorrectly formed URLs (e.g., `/api/v1/api/v1/...`).

The fix removes the `/api/v1` prefix from all paths in the workflow definition file, making them relative to the base URL as intended.