### PR TITLE
fix: Correct API paths in client and test-client

### DIFF
--- a/client/src/pages/test-client/steps/B1_createSite.ts
+++ b/client/src/pages/test-client/steps/B1_createSite.ts
@@ -26,7 +26,7 @@ export async function createSite(input: StepInput): Promise<CreateSiteOutput> {
     requested_by_id: safetyManager.id,
   };
 
-  const response = await apiAdapter.post('SAFETY_MANAGER', '/sites/', siteData);
+  const response = await apiAdapter.post('SAFETY_MANAGER', '/org/sites', siteData);
   const siteId = response.data.id;
 
   if (!siteId) {

--- a/client/src/pages/test-client/steps/B2_approveSite.ts
+++ b/client/src/pages/test-client/steps/B2_approveSite.ts
@@ -19,5 +19,5 @@ export async function approveSite(input: ApproveSiteInput): Promise<void> {
     approved_by_id: manufacturer.id,
   };
 
-  await apiAdapter.patch('MANUFACTURER', `/sites/${siteId}`, approveData);
+  await apiAdapter.patch('MANUFACTURER', `/org/sites/${siteId}`, approveData);
 }

--- a/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
+++ b/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
@@ -13,7 +13,7 @@ export async function listOwnerCranes(input: StepInput): Promise<ListOwnerCranes
     throw new Error('Owner not found in context');
   }
 
-  const response = await apiAdapter.get('OWNER', `/owners/${owner.orgId}/cranes`);
+  const response = await apiAdapter.get('OWNER', `/org/owners/${owner.orgId}/cranes`);
   const cranes = response.data;
 
   if (!cranes || cranes.length === 0) {

--- a/client/src/pages/test-client/steps/C3_createCraneAssignment.ts
+++ b/client/src/pages/test-client/steps/C3_createCraneAssignment.ts
@@ -35,7 +35,7 @@ export async function createCraneAssignment(
 
   const response = await apiAdapter.post(
     'SAFETY_MANAGER',
-    '/crane-assignments',
+    '/ops/crane-deployments',
     assignmentData
   );
 

--- a/client/src/pages/test-client/steps/D1_assignDriver.ts
+++ b/client/src/pages/test-client/steps/D1_assignDriver.ts
@@ -31,7 +31,7 @@ export async function assignDriver(input: AssignDriverInput): Promise<AssignDriv
 
   const response = await apiAdapter.post(
     'OWNER',
-    '/driver-assignments',
+    '/ops/driver-deployments',
     assignDriverData
   );
 

--- a/client/src/pages/test-client/steps/D2_recordAttendance.ts
+++ b/client/src/pages/test-client/steps/D2_recordAttendance.ts
@@ -17,5 +17,5 @@ export async function recordAttendance(input: RecordAttendanceInput): Promise<vo
     check_out_at: `${workDate.toISOString().split('T')[0]}T17:00:00Z`,
   };
 
-  await apiAdapter.post('DRIVER', '/attendances', attendanceData);
+  await apiAdapter.post('DRIVER', '/ops/driver-attendance-logs', attendanceData);
 }

--- a/client/src/pages/test-client/steps/E1_requestDocument.ts
+++ b/client/src/pages/test-client/steps/E1_requestDocument.ts
@@ -32,7 +32,7 @@ export async function requestDocument(
 
   const response = await apiAdapter.post(
     'SAFETY_MANAGER',
-    '/document-requests',
+    '/compliance/document-requests',
     docRequestData
   );
 

--- a/client/src/pages/test-client/steps/E2_submitDocument.ts
+++ b/client/src/pages/test-client/steps/E2_submitDocument.ts
@@ -32,7 +32,7 @@ export async function submitDocument(
 
   const response = await apiAdapter.post(
     'DRIVER',
-    '/document-items',
+    '/compliance/document-items',
     docSubmitData
   );
 

--- a/client/src/pages/test-client/steps/E3_reviewDocument.ts
+++ b/client/src/pages/test-client/steps/E3_reviewDocument.ts
@@ -19,5 +19,9 @@ export async function reviewDocument(input: ReviewDocumentInput): Promise<void> 
     approve: true,
   };
 
-  await apiAdapter.patch('SAFETY_MANAGER', `/document-items/${docItemId}`, docReviewData);
+  await apiAdapter.post(
+    'SAFETY_MANAGER',
+    `/compliance/document-items/${docItemId}/review`,
+    docReviewData
+  );
 }


### PR DESCRIPTION
This commit fixes a bug where the client and test client were experiencing 404 errors after the API v1 refactoring. The API paths in several client-side files were not updated correctly.

- Updates the `baseURL` in `apiClient.ts` to `/api/v1`.
- Corrects the relative paths used in various page components.
- Corrects the API paths in the test client workflow definition (`workflow-def.ts`) to be relative to the new base URL.
- Corrects the API paths in the individual test client step files (`test-client/steps/*.ts`).
- This completes the full-stack refactoring of the API to the new v1 URL structure.