### PR TITLE
fix(client): Remove redundant item_id from document review payload

### DIFF
--- a/client/src/pages/test-client/steps/E3_reviewDocument.ts
+++ b/client/src/pages/test-client/steps/E3_reviewDocument.ts
@@ -14,7 +14,6 @@ export async function reviewDocument(input: ReviewDocumentInput): Promise<void> 
   }
 
   const docReviewData = {
-    item_id: docItemId,
     reviewer_id: safetyManager.id,
     approve: true,
   };


### PR DESCRIPTION
The API call to review a document at `POST /compliance/document-items/{docItemId}/review` was failing with a 404 error.

Investigation revealed that the client was sending the document's ID in both the URL path and the request body. A comment in the server-side code explicitly states that the ID should only be passed in the path.

This change corrects the client-side implementation by removing the `item_id` field from the JSON payload of the review request. This aligns the client with the server's expectation and resolves the 404 error.