### PR TITLE
Fix: Add missing item_id to document review payload

### DIFF
--- a/client/src/pages/test-client/steps/E3_reviewDocument.ts
+++ b/client/src/pages/test-client/steps/E3_reviewDocument.ts
@@ -14,6 +14,7 @@ export async function reviewDocument(input: ReviewDocumentInput): Promise<void> 
   }
 
   const docReviewData = {
+    item_id: docItemId,
     reviewer_id: safetyManager.id,
     approve: true,
   };


### PR DESCRIPTION
The client was receiving a 422 Unprocessable Content error when submitting a document review (Test Client Step E3).

This was caused by a missing `item_id` field in the JSON payload of the POST request to `/api/v1/compliance/document-items/{itemId}/review`.

The OpenAPI specification for the `DocItemReviewIn` schema requires this field. This change adds the `docItemId` to the request body to align with the API contract and resolve the error.