### PR TITLE
fix(test-client): Select available crane for assignment

### DIFF
--- a/backend.log
+++ b/backend.log
@@ -1,0 +1,14 @@
+INFO:     Will watch for changes in these directories: ['/app']
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [5379] using WatchFiles
+2025-09-03 04:31:08,870 - server.main - INFO - Logging configured - Level: INFO, Environment: development
+2025-09-03 04:31:08,896 - server.main - INFO - Application module loaded - DY Crane Safety Management API v1.0.0
+INFO:     Started server process [5383]
+INFO:     Waiting for application startup.
+2025-09-03 04:31:08,897 - server.main - INFO - ============================================================
+2025-09-03 04:31:08,897 - server.main - INFO - Starting DY Crane Safety Management API v1.0.0
+2025-09-03 04:31:08,897 - server.main - INFO - ============================================================
+2025-09-03 04:31:08,923 - server.main - INFO - Database connectivity verified
+2025-09-03 04:31:08,923 - server.main - INFO - API server ready at http://127.0.0.1:8000
+2025-09-03 04:31:08,923 - server.main - INFO - Documentation available at http://127.0.0.1:8000/docs
+INFO:     Application startup complete.

--- a/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
+++ b/client/src/pages/test-client/steps/C1_listOwnerCranes.ts
@@ -13,12 +13,13 @@ export async function listOwnerCranes(input: StepInput): Promise<ListOwnerCranes
     throw new Error('Owner not found in context');
   }
 
-  const response = await apiAdapter.get('OWNER', `/org/owners/${owner.orgId}/cranes`);
+  const response = await apiAdapter.get('OWNER', `/org/owners/${owner.orgId}/cranes?status=NORMAL`);
   const cranes = response.data;
 
   if (!cranes || cranes.length === 0) {
-    throw new Error('No cranes found for owner');
+    throw new Error('No available cranes found for owner');
   }
 
+  // Return the first available crane
   return { craneId: cranes[0].id };
 }


### PR DESCRIPTION
The test client was failing at step C3 because it was selecting a crane without considering its status. If the selected crane was in a 'REPAIR' state, the database would correctly reject the assignment, causing the test to fail.

This fix modifies step C1 of the test client to filter for cranes with the 'NORMAL' status, ensuring that only available cranes are selected for assignment. This prevents the intermittent test failures.