### PR TITLE
fix: Resolve 422 error by updating test email domains

### DIFF
--- a/client/src/pages/test-client/steps/A1_SafetyManagerLogin.ts
+++ b/client/src/pages/test-client/steps/A1_SafetyManagerLogin.ts
@@ -2,7 +2,7 @@ import { apiAdapter } from '../transport/apiAdapter';
 import { StepInput, StepOutput } from './types';
 
 const USER_ROLE = 'SAFETY_MANAGER';
-const USER_EMAIL = 'safety1@dy.local';
+const USER_EMAIL = 'safety1@example.com';
 
 export async function safetyManagerLogin(input: StepInput): Promise<StepOutput> {
   const { addLog } = input.actions;

--- a/client/src/pages/test-client/steps/A2_ManufacturerLogin.ts
+++ b/client/src/pages/test-client/steps/A2_ManufacturerLogin.ts
@@ -2,7 +2,7 @@ import { apiAdapter } from '../transport/apiAdapter';
 import { StepInput, StepOutput } from './types';
 
 const USER_ROLE = 'MANUFACTURER';
-const USER_EMAIL = 'mfr1@dy.local';
+const USER_EMAIL = 'mfr1@example.com';
 
 export async function manufacturerLogin(input: StepInput): Promise<StepOutput> {
   const { addLog } = input.actions;

--- a/client/src/pages/test-client/steps/A3_DriverLogin.ts
+++ b/client/src/pages/test-client/steps/A3_DriverLogin.ts
@@ -2,7 +2,7 @@ import { apiAdapter } from '../transport/apiAdapter';
 import { StepInput, StepOutput } from './types';
 
 const USER_ROLE = 'DRIVER';
-const USER_EMAIL = 'driver1@dy.local';
+const USER_EMAIL = 'driver1@example.com';
 
 export async function driverLogin(input: StepInput): Promise<StepOutput> {
   const { addLog } = input.actions;

--- a/scripts/db_seeder.py
+++ b/scripts/db_seeder.py
@@ -32,16 +32,16 @@ ORGS = [
 ]
 
 USERS = [
-    {"id": "user-safety-manager-01", "email": "safety1@dy.local", "name": "Safety Manager One", "role": UserRole.SAFETY_MANAGER},
-    {"id": "user-manufacturer-01", "email": "mfr1@dy.local", "name": "Manufacturer Admin", "role": UserRole.MANUFACTURER, "org_id": "org-mfg-01"},
-    {"id": "user-owner-01", "email": "owner1@dy.local", "name": "Owner One (Total)", "role": UserRole.OWNER, "org_id": "org-owner-01"},
-    {"id": "user-owner-02", "email": "owner2@dy.local", "name": "Owner Two (Apex)", "role": UserRole.OWNER, "org_id": "org-owner-02"},
-    {"id": "user-owner-03", "email": "owner3@dy.local", "name": "Owner Three (Summit)", "role": UserRole.OWNER, "org_id": "org-owner-03"},
-    {"id": "user-owner-04", "email": "owner4@dy.local", "name": "Owner Four (Bedrock)", "role": UserRole.OWNER, "org_id": "org-owner-04"},
-    {"id": "user-owner-05", "email": "owner5@dy.local", "name": "Owner Five (SkyHigh)", "role": UserRole.OWNER, "org_id": "org-owner-05"},
-    {"id": "user-driver-01", "email": "driver1@dy.local", "name": "Driver A", "role": UserRole.DRIVER},
-    {"id": "user-driver-02", "email": "driver2@dy.local", "name": "Driver B", "role": UserRole.DRIVER},
-    {"id": "user-driver-03", "email": "driver3@dy.local", "name": "Driver C", "role": UserRole.DRIVER},
+    {"id": "user-safety-manager-01", "email": "safety1@example.com", "name": "Safety Manager One", "role": UserRole.SAFETY_MANAGER},
+    {"id": "user-manufacturer-01", "email": "mfr1@example.com", "name": "Manufacturer Admin", "role": UserRole.MANUFACTURER, "org_id": "org-mfg-01"},
+    {"id": "user-owner-01", "email": "owner1@example.com", "name": "Owner One (Total)", "role": UserRole.OWNER, "org_id": "org-owner-01"},
+    {"id": "user-owner-02", "email": "owner2@example.com", "name": "Owner Two (Apex)", "role": UserRole.OWNER, "org_id": "org-owner-02"},
+    {"id": "user-owner-03", "email": "owner3@example.com", "name": "Owner Three (Summit)", "role": UserRole.OWNER, "org_id": "org-owner-03"},
+    {"id": "user-owner-04", "email": "owner4@example.com", "name": "Owner Four (Bedrock)", "role": UserRole.OWNER, "org_id": "org-owner-04"},
+    {"id": "user-owner-05", "email": "owner5@example.com", "name": "Owner Five (SkyHigh)", "role": UserRole.OWNER, "org_id": "org-owner-05"},
+    {"id": "user-driver-01", "email": "driver1@example.com", "name": "Driver A", "role": UserRole.DRIVER},
+    {"id": "user-driver-02", "email": "driver2@example.com", "name": "Driver B", "role": UserRole.DRIVER},
+    {"id": "user-driver-03", "email": "driver3@example.com", "name": "Driver C", "role": UserRole.DRIVER},
 ]
 
 CRANE_MODELS = [


### PR DESCRIPTION
This commit fixes a `422 Unprocessable Content` error that occurred during login. The error was caused by the `pydantic.EmailStr` validator rejecting the non-standard `@dy.local` domain used in the test data.

-   **Backend**: Updated `scripts/db_seeder.py` to use `@example.com` for all seed user emails, which is a standards-compliant domain for testing.
-   **Frontend**: Updated the corresponding email addresses in the test client's login steps (`A1_...`, `A2_...`, `A3_...`) to match the new seed data.

This change ensures that the test data is valid according to the server's validation rules, allowing the login flow to succeed.