### PR TITLE
docs: Refactor documentation and add prompt management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,12 @@
-# DY Crane Safety Management API
+# DY Crane Safety Management API (v0.4.0)
 
-Welcome to the DY Crane Safety Management project! This repository contains the backend API and a frontend interactive test client for a comprehensive crane safety management system.
+Welcome to the project repository. This project includes a FastAPI backend and a React-based interactive test client.
 
-The primary goal of this project is to provide a robust, well-documented, and maintainable system for managing construction sites, cranes, drivers, and safety documents. A key feature is the **Developer Guide Test Client**, which serves as a living, interactive form of documentation for the entire business workflow.
+- **For full documentation, see [docs/index.md](./docs/index.md).**
+- **For setup & contribution instructions, see [docs/CONTRIBUTING.md](./docs/CONTRIBUTING.md).**
 
-## Project Documentation
-
-This project's documentation is organized in the `docs/` directory.
-
--   **[README.md](README.md)** (You are here): High-level overview and project entry point.
--   **[CONTRIBUTING.md](docs/CONTRIBUTING.md)**: The essential guide for developers. Contains detailed instructions on setting up your local environment, running the application, and contributing to the project.
--   **[TEST_CLIENT_GUIDE.md](docs/TEST_CLIENT_GUIDE.md)**: A detailed guide to the interactive `/test-client`, explaining each step of the business workflow.
--   **[WORKFLOW_DIAGRAM.md](docs/WORKFLOW_DIAGRAM.md)**: A sequence diagram that visually represents the entire end-to-end workflow.
--   **[API_RULEBOOK.md](docs/API_RULEBOOK.md)**: The rules and conventions for API design.
--   **[RELEASES.md](docs/RELEASES.md)**: Contains release notes and a summary of changes for each version.
--   **[openapi.yaml](openapi.yaml)**: The full OpenAPI (Swagger) specification for the backend API.
-
-## Quick Start
-
-For the full development setup guide, please see **[CONTRIBUTING.md](docs/CONTRIBUTING.md)**.
-
-Here is a brief overview of the steps:
-
-1.  **Prerequisites**: Ensure you have Git, PostgreSQL, Python 3.8+, and Node.js 16+ installed.
-2.  **Clone & Configure**:
-    ```sh
-    git clone https://github.com/your-username/dycrane_backend_proto.git
-    cd dycrane_backend_proto
-    cp .env.example .env
-    # Edit .env with your PostgreSQL details
-    ```
-3.  **Initialize & Seed Database**:
-    This command sets up the Python virtual environment, installs dependencies, creates the database, and seeds it with master data.
-    ```sh
-    ./scripts/dev.sh db/full
-    ```
-4.  **Run Backend Server**:
-    ```sh
-    .venv/bin/uvicorn server.main:app --reload
-    # API is now running on http://localhost:8000
-    ```
-5.  **Run Frontend Dev Server**:
-    In a new terminal:
-    ```sh
-    cd client
-    npm install
-    npm run dev
-    # Frontend is now running on http://localhost:3000
-    ```
-
-## Using the Developer Guide Test Client
-
-Navigate to `http://localhost:3000/test-client` in your browser to access the interactive workflow tool.
-
--   **Purpose**: To visualize, test, and understand the end-to-end business logic.
--   **"Auto Run All"**: Executes the entire A1-F2 workflow.
--   **"Reset Workflow Data"**: Before running the workflow, especially for a second time, press this button. It clears all previous transactional data from the server to prevent `409 Conflict` errors.
-
-For a full explanation of each step and how to use the client, please read the **[TEST_CLIENT_GUIDE.md](docs/TEST_CLIENT_GUIDE.md)**.
-
-## Project Structure
-
-The project is organized into a layered architecture for the backend and a modern component-based structure for the frontend.
-
--   `server/`: Python FastAPI backend.
-    -   `api/`: API routers and endpoints.
-    -   `domain/`: Core business logic, schemas, and database models.
-    -   `sql/`: Database schema and reset scripts.
--   `client/`: TypeScript React frontend (Vite).
-    -   `src/pages/test-client/`: The source code for the developer guide test client.
--   `scripts/`: Helper scripts for development and database management.
--   `tests/`: E2E and unit tests.
-
-We encourage you to read **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** for a deeper dive into the project structure and our development practices.
+### Quick Links
+- **API Specification**: [openapi.yaml](./openapi.yaml)
+- **Test Client**: The application must be running to access the client at `http://localhost:3000/test-client`.
+- **Prompts Catalog**: [docs/prompts/README.md](./docs/prompts/README.md)
+- **Report Example**: [report.md](./report.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Documentation Index (v0.4.0)
+
+## Overview
+This project provides a backend API and an interactive test client for a comprehensive crane safety management system. The primary goal is to create a robust, well-documented, and maintainable system for managing construction sites, cranes, drivers, and safety documents.
+
+## Table of Contents
+- **[Getting Started](./CONTRIBUTING.md)**: The essential guide for developers. Contains detailed instructions on setting up your local environment, running the application, and contributing to the project.
+- **[Test Client Guide](./TEST_CLIENT_GUIDE.md)**: A detailed guide to the interactive `/test-client`, explaining each step of the business workflow.
+- **[API Rulebook](./API_RULEBOOK.md)**: The rules and conventions for API design.
+- **[Workflow Diagram](./WORKFLOW_DIAGRAM.md)**: A sequence diagram that visually represents the entire end-to-end workflow.
+- **[Release Notes](./RELEASES.md)**: A summary of changes for each version.
+- **[AI Prompts Catalog](./prompts/README.md)**: A collection of reusable prompts for AI-assisted development tasks.
+- **[report.md](../report.md)**: An example of a generated API-to-Database correlation report.
+
+## Conventions
+- **Documentation First**: For any significant change, update the relevant documentation in the same pull request.
+- **Keep Links Updated**: If files are moved, ensure all relative links in the documentation are updated.
+- **PR Checklist**: When submitting a pull request, ensure it has been reviewed against the contribution guidelines and that any new features are reflected in the documentation.
+
+## Changelog Highlights
+- **v0.4**: Multi-user login in the test client, documentation restructured into a `docs/` folder, and AI prompt management system introduced.
+- **v0.1**: Initial development, including the interactive test client and server state reset functionality.

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -1,0 +1,9 @@
+# Prompts Catalog
+
+This directory stores standardized, reusable prompts for AI-assisted development tasks.
+
+| File | Purpose | Input | Output | Owner | Version |
+|------|---------|-------|--------|-------|---------|
+| [generate_report_prompt.md](./generate_report_prompt.md) | Generate API-to-Database correlation report | Source code, SQL schemas | Markdown | @jules | 1.0.0 |
+
+**Tags**: `domain:docs`, `action:generate`, `output:md`

--- a/docs/prompts/generate_report_prompt.md
+++ b/docs/prompts/generate_report_prompt.md
@@ -1,0 +1,97 @@
+---
+title: "Generate API–Database Correlation Report"
+version: "1.0.0"
+last_reviewed: "2025-09-03"
+owner: "@jules"
+inputs_required:
+  - "Full source code access (FastAPI)"
+  - "SQL schema definition files (`.sql`)"
+expected_output:
+  format: "Markdown (report.md)"
+  sections:
+    - "Endpoint-to-Table Mapping"
+    - "Endpoint-to-View Mapping"
+    - "Endpoint-to-Function/Procedure Mapping"
+    - "Unresolved References"
+constraints:
+  - "Must perform static analysis only (no live DB execution)"
+  - "Must cross-reference the defining SQL file for each DB object"
+---
+
+# AI Prompt — Generate API–Database Correlation Report (Markdown)
+
+You are an assistant analyzing a project that contains both **API source code** and **SQL definition files** (such as `init_db.sql`, `init_view.sql`, and other files defining tables, views, functions, and stored procedures).
+
+Your task is to produce a **single Markdown report (`report.md`)** that maps every API endpoint to the database objects it references.
+
+---
+
+## Step 1. Collect API Endpoints
+
+* Identify all API endpoints defined in the project.
+* For each endpoint, record:
+
+  * HTTP method (GET, POST, etc.)
+  * Path (e.g., `/api/cranes`)
+  * Source file and handler function name
+
+---
+
+## Step 2. Extract Database Usage
+
+* Inspect the handler logic to detect:
+
+  * SQL queries written directly in code
+  * ORM queries (e.g., SQLAlchemy)
+  * Calls to functions, procedures, or views
+* Normalize the extracted database identifiers.
+
+---
+
+## Step 3. Parse SQL Files
+
+* Read the SQL files provided in the project.
+* Identify definitions for:
+
+  * `CREATE TABLE` → Tables
+  * `CREATE VIEW` / `CREATE MATERIALIZED VIEW` → Views
+  * `CREATE FUNCTION` → Functions
+  * `CREATE PROCEDURE` → Procedures
+* Build a dictionary of available database objects.
+
+---
+
+## Step 4. Correlate APIs to Database Objects
+
+* Match the database identifiers used in API handlers to the definitions found in the SQL files.
+* If a match exists, classify the object as TABLE, VIEW, FUNCTION, or PROCEDURE, and note the source SQL file.
+* If unresolved, mark as **Unknown** but include the raw SQL or reference string.
+
+---
+
+## Step 5. Generate the Markdown Report
+
+Output the final deliverable in **Markdown format** with the following structure:
+
+* Title and metadata (generation timestamp, DB type).
+* One section per API endpoint containing:
+
+  * HTTP method and path
+  * Source file and handler name
+  * Extracted SQL or query description (inline, no code fences)
+  * Database objects referenced (with type and originating SQL file)
+  * Notes for skipped or unresolved items
+
+---
+
+## Step 6. Completion Criteria
+
+The task is complete when the Markdown report satisfies all of the following:
+
+* A file named `report.md` is generated.
+* Every API endpoint is documented with its method, path, and handler.
+* At least one SQL snippet or reference is listed for each endpoint (if available).
+* Database objects (TABLE, VIEW, FUNCTION, PROCEDURE) are identified and classified.
+* Cross-references to the defining SQL file are included.
+* Unresolved or ambiguous cases are explicitly documented as **Unknown**.
+* No live database execution is required — all information must come from static analysis of code and SQL files.

--- a/scripts/view_prompt.ps1
+++ b/scripts/view_prompt.ps1
@@ -1,0 +1,12 @@
+param(
+  [string]$PromptPath = "docs/prompts/generate_report_prompt.md"
+)
+
+if (!(Test-Path $PromptPath)) {
+  Write-Error "Prompt not found: $PromptPath"
+  exit 1
+}
+
+Write-Host "===== BEGIN PROMPT: $PromptPath ====="
+Get-Content -Path $PromptPath | ForEach-Object { $_ }
+Write-Host "`n===== END PROMPT ====="

--- a/scripts/view_prompt.sh
+++ b/scripts/view_prompt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT_PATH="docs/prompts/generate_report_prompt.md"
+
+if [ ! -f "$PROMPT_PATH" ]; then
+  echo "Prompt not found: $PROMPT_PATH" >&2
+  exit 1
+fi
+
+echo "===== BEGIN PROMPT: $PROMPT_PATH ====="
+cat "$PROMPT_PATH"
+echo
+echo "===== END PROMPT ====="


### PR DESCRIPTION
This commit introduces a major overhaul of the project's documentation structure and adds a system for managing reusable AI prompts.

Key changes:
-   **New `docs/` Directory**: All markdown documentation files have been moved into a centralized `docs/` folder to clean up the project root.
-   **New `docs/index.md`**: A new main documentation index file has been created to serve as the primary entry point for all project documentation.
-   **Simplified Root `README.md`**: The `README.md` in the root directory has been simplified to a concise overview with links to the full documentation and contribution guide.
-   **Prompt Management System**:
    -   A new `docs/prompts/` directory has been created to store AI prompts.
    -   Added a prompt for generating an API-to-Database correlation report, complete with YAML frontmatter for metadata.
    -   Added a `docs/prompts/README.md` to serve as a catalog for the prompts.
-   **Helper Scripts**: Created cross-platform scripts (`view_prompt.sh` and `view_prompt.ps1`) to make it easy for developers to view and use the stored prompts.
-   **Content Updates**: All documentation has been updated to reflect the v0.4.0 changes, including the new authentication system and multi-user test client workflow.